### PR TITLE
fix: Handle null values for optional types

### DIFF
--- a/src/__tests__/builtin-scalars.spec.ts
+++ b/src/__tests__/builtin-scalars.spec.ts
@@ -1,0 +1,56 @@
+import {
+  ApolloLink,
+  DocumentNode,
+  execute,
+  getOperationName,
+  GraphQLRequest,
+  Observable
+} from "apollo-link";
+import gql from "graphql-tag";
+import { makeExecutableSchema } from "graphql-tools";
+import { withScalars } from "..";
+
+const typeDefs = gql`
+  type Query {
+    day: String
+  }
+`;
+
+const schema = makeExecutableSchema({ typeDefs });
+
+const queryDocument: DocumentNode = gql`
+  query MyQuery {
+    day
+  }
+`;
+const queryOperationName = getOperationName(queryDocument);
+if (!queryOperationName) throw new Error("invalid query operation name");
+
+const request: GraphQLRequest = {
+  query: queryDocument,
+  variables: {},
+  operationName: queryOperationName
+};
+
+const response = {
+  data: {
+    day: null
+  }
+};
+
+describe("builtin scalars behave like usual", () => {
+  it("parses null values for nullable leaf types", done => {
+    const link = ApolloLink.from([
+      withScalars({ schema }),
+      new ApolloLink(() => {
+        return Observable.of(response);
+      })
+    ]);
+
+    const observable = execute(link, request);
+    observable.subscribe(result => {
+      expect(result).toEqual({ data: { day: null } });
+      done();
+    });
+  });
+});

--- a/src/__tests__/scalar-from-query.spec.ts
+++ b/src/__tests__/scalar-from-query.spec.ts
@@ -169,7 +169,7 @@ describe("scalar returned directly from first level queries", () => {
     expect.assertions(1);
   });
 
-  it("override the scala resolvers with the custom functions map", done => {
+  it("override the scalar resolvers with the custom functions map", done => {
     const link = ApolloLink.from([
       withScalars({ schema, typesMap }),
       new ApolloLink(() => {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -66,6 +66,8 @@ export class Parser {
     fieldNode: ReducedFieldNode
   ): any {
     const type = ensureNullableType(value, givenType, fieldNode);
+    if (isNone(value)) return value;
+
     if (isScalarType(type)) {
       return this.parseScalar(value, type);
     }
@@ -74,8 +76,6 @@ export class Parser {
       this.validateEnum(value, type);
       return value;
     }
-
-    if (isNone(value)) return value;
 
     if (isListType(type)) {
       return this.parseArray(value, type, fieldNode);


### PR DESCRIPTION
Without this change, I'm not able to get `apollo-link-scalars` running in my project.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a bugfix.

* **What is the current behavior?** (You can also link to an open issue here)

`apollo-link-scalars` errors for valid `null` values of nullable types with errors like:

```
TypeError: String cannot represent a non string value: null
```

The errors are hard to track down as they occur during the Apollo client initialization.

* **What is the new behavior (if this is a feature change)?**

`apollo-link-scalars` won't error on nullable scalar types anymore.
