### PR TITLE
fix: TypeError on different "graphql" versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ withScalars({
 ```typescript
 import gql from "graphql-tag";
 import { GraphQLScalarType, Kind } from "graphql";
-import { makeExecutableSchema } from "graphql-tools";
+import { makeExecutableSchema } from "apollo-link-scalars";
 
 // GraphQL Schema definition.
 const typeDefs = gql`

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ import { isNone } from "./lib/is-none";
 import { ScalarApolloLink, withScalars } from "./lib/link";
 import { mapIfArray } from "./lib/map-if-array";
 import { FunctionsMap, ParsingFunctionsObject } from "./types/functions-map";
+import { makeExecutableSchema } from "graphql-tools";
 
-export { FunctionsMap, isNone, mapIfArray, ParsingFunctionsObject, ScalarApolloLink, withScalars };
+export { FunctionsMap, isNone, mapIfArray, ParsingFunctionsObject, ScalarApolloLink, withScalars, makeExecutableSchema };


### PR DESCRIPTION
If there is a difference in the versions of "graphql" used by "apollo-link-scalars" and the project including it there might be difference in the structure of the schema instance created by `makeExecutableSchema`. This is the case with "graphql" 14.x and 15.x. and will result in a TypeError - "The types returned by 'getQueryType()' are incompatible between these types.".

To fix this I am exposing `makeExecutableSchema` through "apollo-link-scalars" to ensure that the types in the generated schema will be compatible by those expected from `withScalars`.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
My project is using "graphql" version "15.3.0" and the one used by "apollo-link-scalars" is "14.5.8". I am getting the following TypeError:

```
app/javascript/gamma/utils/apollo.ts:47:29 - error TS2322: Type 'import(".../dev/.../application/node_modules/graphql/type/schema").GraphQLSchema' is not assignable to type 'import(".../dev/apollo-link-scalars/node_modules/graphql/type/schema").GraphQLSchema'.
  The types returned by 'getQueryType()' are incompatible between these types.
    Type 'Maybe<GraphQLObjectType<any, any>>' is not assignable to type 'Maybe<GraphQLObjectType<any, any, { [key: string]: any; }>>'.
      Type 'GraphQLObjectType<any, any>' is not assignable to type 'Maybe<GraphQLObjectType<any, any, { [key: string]: any; }>>'.
        Types of property 'isTypeOf' are incompatible.
          Type 'import("/Users/dobrinov/dev/receipt-bank/application/node_modules/graphql/jsutils/Maybe").Maybe<import(".../dev/receipt-bank/application/node_modules/graphql/type/definition").GraphQLIsTypeOfFn<any, any>>' is not assignable to type 'import("/Users/dobrinov/dev/apollo-link-scalars/node_modules/graphql/tsutils/Maybe").default<import(".../dev/apollo-link-scalars/node_modules/graphql/type/definition").GraphQLIsTypeOfFn<any, any>>'.
            Type 'GraphQLIsTypeOfFn<any, any>' is not assignable to type 'Maybe<GraphQLIsTypeOfFn<any, any>>'.
              Types of parameters 'info' and 'info' are incompatible.
                Type 'import(".../dev/apollo-link-scalars/node_modules/graphql/type/definition").GraphQLResolveInfo' is not assignable to type 'import(".../dev/receipt-bank/application/node_modules/graphql/type/definition").GraphQLResolveInfo'.
                  Types of property 'fieldNodes' are incompatible.
                    Type 'readonly import(".../dev/apollo-link-scalars/node_modules/graphql/language/ast").FieldNode[]' is not assignable to type 'readonly import(".../dev/.../application/node_modules/graphql/language/ast").FieldNode[]'.
                      Type 'import(".../dev/apollo-link-scalars/node_modules/graphql/language/ast").FieldNode' is not assignable to type 'import(".../dev/receipt-bank/.../node_modules/graphql/language/ast").FieldNode'.
                        Types of property 'loc' are incompatible.
                          Type 'import(".../dev/apollo-link-scalars/node_modules/graphql/language/ast").Location | undefined' is not assignable to type 'import(".../dev/.../application/node_modules/graphql/language/ast").Location | undefined'.
                            Property 'toJSON' is missing in type 'import(".../dev/apollo-link-scalars/node_modules/graphql/language/ast").Location' but required in type 'import(".../dev/receipt-bank/application/node_modules/graphql/language/ast").Location'.
```


* **What is the new behavior (if this is a feature change)?**
n/a


* **Other information**:
n/a