### PR TITLE
refactor: upgrade "apollo-link" to provide Apollo client version 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ You can build the link by calling the `withScalars()` function, passing to it th
 
 ```typescript
 import { withScalars } from "apollo-link-scalars";
-import { ApolloLink } from "apollo-link";
-import { HttpLink } from "apollo-link-http";
+import { ApolloLink, HttpLink } from "@apollo/client";
 import { schema } from "./my-schema";
 
 const link = ApolloLink.from([
@@ -80,7 +79,7 @@ withScalars({
 ### Example of loading a schema
 
 ```typescript
-import gql from "graphql-tag";
+import { gql } from "@apollo/client";
 import { GraphQLScalarType, Kind } from "graphql";
 import { makeExecutableSchema } from "graphql-tools";
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node": ">=10.0"
   },
   "dependencies": {
-    "apollo-link": "^1.2.13",
+    "@apollo/client": "^3.0.2",
     "graphql": "^14.5.8",
     "lodash": "^4.17.15",
     "zen-observable-ts": "^0.8.21"
@@ -64,11 +64,11 @@
     "@types/inquirer": "^6.5.0",
     "@types/jest": "^26.0.0",
     "@types/lodash": "^4.14.149",
+    "@types/react": "^16.9.43",
     "apollo-server-testing": "^2.12.0",
     "cz-conventional-changelog": "^3.1.0",
     "gh-pages": "^3.1.0",
     "github-release-from-changelog": "^2.1.1",
-    "graphql-tag": "^2.10.3",
     "graphql-tools": "^6.0.10",
     "husky": "^4.2.5",
     "inquirer": "^7.1.0",

--- a/src/__tests__/builtin-scalars.spec.ts
+++ b/src/__tests__/builtin-scalars.spec.ts
@@ -1,5 +1,5 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
-import gql from "graphql-tag";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { makeExecutableSchema } from "graphql-tools";
 import { withScalars } from "..";
 

--- a/src/__tests__/ignore-non-nullability.spec.ts
+++ b/src/__tests__/ignore-non-nullability.spec.ts
@@ -1,6 +1,6 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { graphql } from "graphql";
-import gql from "graphql-tag";
 import { makeExecutableSchema } from "graphql-tools";
 import { withScalars } from "..";
 

--- a/src/__tests__/interfaces.spec.ts
+++ b/src/__tests__/interfaces.spec.ts
@@ -1,6 +1,6 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { graphql, GraphQLScalarType, Kind } from "graphql";
-import gql from "graphql-tag";
 import { makeExecutableSchema } from "graphql-tools";
 import { withScalars } from "..";
 

--- a/src/__tests__/scalar-array-from-query.spec.ts
+++ b/src/__tests__/scalar-array-from-query.spec.ts
@@ -1,6 +1,6 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { graphql, GraphQLScalarType, Kind } from "graphql";
-import gql from "graphql-tag";
 import { makeExecutableSchema } from "graphql-tools";
 import { withScalars } from "..";
 

--- a/src/__tests__/scalar-from-object.spec.ts
+++ b/src/__tests__/scalar-from-object.spec.ts
@@ -1,6 +1,6 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { graphql, GraphQLScalarType, Kind } from "graphql";
-import gql from "graphql-tag";
 import { makeExecutableSchema } from "graphql-tools";
 import { withScalars } from "..";
 

--- a/src/__tests__/scalar-from-query.spec.ts
+++ b/src/__tests__/scalar-from-query.spec.ts
@@ -1,6 +1,6 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { graphql, GraphQLScalarType, Kind } from "graphql";
-import gql from "graphql-tag";
 import { makeExecutableSchema } from "graphql-tools";
 import { withScalars } from "..";
 

--- a/src/__tests__/serialize-from-nested.spec.ts
+++ b/src/__tests__/serialize-from-nested.spec.ts
@@ -1,6 +1,6 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { graphql, GraphQLScalarType, Kind } from "graphql";
-import gql from "graphql-tag";
 import { makeExecutableSchema } from "graphql-tools";
 import { cloneDeep, isNumber, isString } from "lodash";
 import { withScalars } from "..";

--- a/src/__tests__/serialize-from-query.spec.ts
+++ b/src/__tests__/serialize-from-query.spec.ts
@@ -1,6 +1,6 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { graphql, GraphQLScalarType, Kind } from "graphql";
-import gql from "graphql-tag";
 import { makeExecutableSchema } from "graphql-tools";
 import { cloneDeep, isNumber, isString } from "lodash";
 import { withScalars } from "..";

--- a/src/__tests__/unions.spec.ts
+++ b/src/__tests__/unions.spec.ts
@@ -1,6 +1,6 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { graphql, GraphQLScalarType, Kind } from "graphql";
-import gql from "graphql-tag";
 import { makeExecutableSchema } from "graphql-tools";
 import { withScalars } from "..";
 

--- a/src/__tests__/validate-enums-from-query.spec.ts
+++ b/src/__tests__/validate-enums-from-query.spec.ts
@@ -1,6 +1,6 @@
-import { ApolloLink, DocumentNode, execute, getOperationName, GraphQLRequest, Observable } from "apollo-link";
+import { gql, ApolloLink, DocumentNode, execute, GraphQLRequest, Observable } from "@apollo/client";
+import { getOperationName } from "@apollo/client/utilities";
 import { graphql } from "graphql";
-import gql from "graphql-tag";
 import { makeExecutableSchema } from "graphql-tools";
 import { withScalars } from "..";
 

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, FetchResult, NextLink, Observable, Operation } from "apollo-link";
+import { ApolloLink, FetchResult, NextLink, Observable, Operation } from "@apollo/client";
 import { GraphQLSchema, isInputType, isLeafType, NamedTypeNode, TypeNode } from "graphql";
 import { pickBy } from "lodash";
 import { ZenObservable } from "zen-observable-ts";

--- a/src/lib/treat-result.ts
+++ b/src/lib/treat-result.ts
@@ -1,4 +1,4 @@
-import { FetchResult, Operation } from "apollo-link";
+import { FetchResult, Operation } from "@apollo/client";
 import { GraphQLObjectType, GraphQLSchema, OperationDefinitionNode } from "graphql";
 import { FunctionsMap } from "..";
 import { fragmentReducer } from "./fragment-reducer";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "resolveJsonModule": true,
     "declaration": true,
     "inlineSourceMap": true,
+    "skipLibCheck": false,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     "strict": true /* Enable all strict type-checking options. */,
     /* Strict Type-Checking Options */

--- a/tslint.json
+++ b/tslint.json
@@ -15,6 +15,7 @@
     "no-implicit-dependencies": [true, "dev"],
     "object-literal-sort-keys": [false],
     "no-console": [false],
-    "interface-over-type-literal": [false]
+    "interface-over-type-literal": [false],
+    "no-submodule-imports": ["@apollo/client/utilities"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+"@apollo/client@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.0.2.tgz#fadb2b39a0e32950baaef2566442cb3f6de74a52"
+  integrity sha512-4ighan5Anlj4tK/tdUHs4Mi1njqXZ7AxRCVolz/H702DjPphAJfm+FRkIadPTmwz+OLO+d+tX+6V1VBshf02rg==
+  dependencies:
+    "@types/zen-observable" "^0.8.0"
+    "@wry/context" "^0.5.2"
+    "@wry/equality" "^0.1.9"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.10.4"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.12.1"
+    prop-types "^15.7.2"
+    symbol-observable "^1.2.0"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+    zen-observable "^0.8.14"
+
 "@apollo/protobufjs@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.0.4.tgz#cf01747a55359066341f31b5ce8db17df44244e0"
@@ -1610,6 +1628,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.1.tgz#b6e98083f13faa1e5231bfa3bdb1b0feff536b6d"
   integrity sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
 "@types/qs@*":
   version "6.9.3"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.3.tgz#b755a0934564a200d3efdf88546ec93c369abd03"
@@ -1619,6 +1642,14 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/react@^16.9.43":
+  version "16.9.43"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.43.tgz#c287f23f6189666ee3bebc2eb8d0f84bcb6cdb6b"
+  integrity sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/serve-static@*":
   version "1.13.4"
@@ -1666,7 +1697,19 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@wry/equality@^0.1.2":
+"@types/zen-observable@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
+  integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
+
+"@wry/context@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.5.2.tgz#f2a5d5ab9227343aa74c81e06533c1ef84598ec7"
+  integrity sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==
+  dependencies:
+    tslib "^1.9.3"
+
+"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
   integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
@@ -1857,7 +1900,7 @@ apollo-link-http-common@^0.2.14:
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
-apollo-link@1.2.14, apollo-link@^1.2.12, apollo-link@^1.2.13, apollo-link@^1.2.14:
+apollo-link@1.2.14, apollo-link@^1.2.12, apollo-link@^1.2.14:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
   integrity sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==
@@ -2969,6 +3012,11 @@ cssstyle@^2.2.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^2.2.0:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
+  integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -4133,7 +4181,12 @@ graphql-extensions@^0.12.3:
     apollo-server-env "^2.4.4"
     apollo-server-types "^0.5.0"
 
-graphql-tag@^2.10.3, graphql-tag@^2.9.2:
+graphql-tag@^2.10.4:
+  version "2.10.4"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.4.tgz#2f301a98219be8b178a6453bb7e33b79b66d8f83"
+  integrity sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA==
+
+graphql-tag@^2.9.2:
   version "2.10.3"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
   integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
@@ -4312,6 +4365,13 @@ highlight.js@^10.0.0:
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.1.1.tgz#691a2148a8d922bf12e52a294566a0d993b94c57"
   integrity sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg==
+
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -5547,7 +5607,7 @@ longest@^2.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-2.0.1.tgz#781e183296aa94f6d4d916dc335d0d17aefa23f8"
   integrity sha1-eB4YMpaqlPbU2RbcM10NF676I/g=
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -6119,7 +6179,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -6224,6 +6284,13 @@ opencollective-postinstall@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
+
+optimism@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.12.1.tgz#933f9467b9aef0e601655adb9638f893e486ad02"
+  integrity sha512-t8I7HM1dw0SECitBYAqFOVHoBAHEQBTeKjIL9y9ImHzAVkdyPK4ifTgM4VJRDtTUY4r/u5Eqxs4XcGPHaoPkeQ==
+  dependencies:
+    "@wry/context" "^0.5.2"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -6610,6 +6677,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -6676,7 +6752,7 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.12.0:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7660,7 +7736,7 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-symbol-observable@^1.0.4:
+symbol-observable@^1.0.4, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -7893,7 +7969,7 @@ try-catch@^3.0.0:
   resolved "https://registry.yarnpkg.com/try-catch/-/try-catch-3.0.0.tgz#7996d8b89895e2e8ae62cbdbeb4fe17470f8131b"
   integrity sha512-3uAqUnoemzca1ENvZ72EVimR+E8lqBbzwZ9v4CEbLjkaV3Q+FtdmPUt7jRtoSoTiYjyIMxEkf6YgUpe/voJ1ng==
 
-ts-invariant@^0.4.0:
+ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
@@ -8597,7 +8673,7 @@ zen-observable-ts@^0.8.21:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable@^0.8.0:
+zen-observable@^0.8.0, zen-observable@^0.8.14:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
This change removes `graphql-tag` and `apollo-link` dependencies and replaces them with `@apollo/client`, which includes both of the removed packages and provides Apollo Client version 3 support.

BREAKING CHANGE: This version of the library won't be compatible with projects using Apollo 2.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
refactoring

* **What is the current behavior?** (You can also link to an open issue here)
n/a

* **What is the new behavior (if this is a feature change)?**
n/a

* **Other information**:
If you are using Apollo Client version 3 in your project with the current version of `apollo-link-scalars` you will get the following type error:
```
error TS2345: Argument of type '(ApolloLink | ApolloLink)[]' is not assignable to parameter of type '(ApolloLink | RequestHandler)[]'.
  Type 'ApolloLink | ApolloLink' is not assignable to type 'ApolloLink | RequestHandler'.
    Type 'ApolloLink' is not assignable to type 'ApolloLink | RequestHandler'.
      Type 'ApolloLink' is missing the following properties from type 'ApolloLink': onError, setOnError

54     link: ApolloLink.from(links),
```

More information on the Apollo Client migration instructions from version 2 to version 3 could be found here - https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/