### PR TITLE
chore(peer-dependencies): move graphql to peer-dependency and allow v14 v15

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ At the time of this writing, Apollo Client still does not support this over 4 ye
 
 ## Installation
 
-`yarn add apollo-link-scalars` or `npm install apollo-link-scalars`.
+`yarn add apollo-link-scalars graphql` or `npm install apollo-link-scalars graphql`.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "keywords": [],
   "scripts": {
+    "prepare": "install-peers",
     "describe": "npm-scripts-info",
     "build": "run-s clean && run-p build:*",
     "build:main": "tsc -p tsconfig.json",
@@ -52,7 +53,6 @@
   },
   "dependencies": {
     "apollo-link": "^1.2.13",
-    "graphql": "^14.5.8",
     "lodash.clonedeep": "^4.5.0",
     "lodash.every": "^4.6.0",
     "lodash.flatmap": "^4.5.0",
@@ -68,10 +68,15 @@
     "lodash.uniqby": "^4.7.0",
     "zen-observable-ts": "^0.8.21"
   },
+  "peerDependencies": {
+    "graphql": "14.x || 15.x"
+  },
   "devDependencies": {
     "@bitjson/npm-scripts-info": "^1.0.0",
     "@commitlint/cli": "^9.0.1",
     "@commitlint/config-conventional": "^9.0.1",
+    "@types/inquirer": "^7.3.0",
+    "@types/jest": "^26.0.0",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.every": "^4.6.6",
     "@types/lodash.flatmap": "^4.5.6",
@@ -85,9 +90,6 @@
     "@types/lodash.pickby": "^4.6.6",
     "@types/lodash.reduce": "^4.6.6",
     "@types/lodash.uniqby": "^4.7.6",
-    "@types/graphql": "^14.5.0",
-    "@types/inquirer": "^7.3.0",
-    "@types/jest": "^26.0.0",
     "apollo-server-testing": "^2.12.0",
     "cz-conventional-changelog": "^3.1.0",
     "gh-pages": "^3.1.0",
@@ -96,6 +98,7 @@
     "graphql-tools": "^6.0.10",
     "husky": "^4.2.5",
     "inquirer": "^7.3.3",
+    "install-peers-cli": "^2.2.0",
     "jest": "^26.1.0",
     "npm-run-all": "^4.1.5",
     "open-cli": "^6.0.1",

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -47,7 +47,7 @@ export class Parser {
 
   protected treatSelection(
     data: Data,
-    fieldMap: GraphQLInputFieldMap | GraphQLFieldMap<any, any, any>,
+    fieldMap: GraphQLInputFieldMap | GraphQLFieldMap<any, any>,
     fieldNode: ReducedFieldNode
   ): Data {
     const name = fieldNode.name.value;
@@ -100,7 +100,7 @@ export class Parser {
 
   protected parseNestedObject(
     value: any,
-    givenType: GraphQLObjectType<any, any, Data> | GraphQLInterfaceType | GraphQLUnionType | GraphQLInputObjectType,
+    givenType: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType | GraphQLInputObjectType,
     fieldNode: ReducedFieldNode
   ): any {
     if (!value || !fieldNode || !fieldNode.selectionSet || !fieldNode.selectionSet.selections.length) {
@@ -114,8 +114,8 @@ export class Parser {
 
   protected getObjectTypeFrom(
     value: any,
-    type: GraphQLObjectType<any, any, Data> | GraphQLInterfaceType | GraphQLUnionType | GraphQLInputObjectType
-  ): GraphQLObjectType<any, any, Data> | GraphQLInputObjectType | null {
+    type: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType | GraphQLInputObjectType
+  ): GraphQLObjectType | GraphQLInputObjectType | null {
     if (isInputObjectType(type) || isObjectType(type)) return type;
     if (!value.__typename) return null;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,13 +1477,6 @@
     "@types/koa" "*"
     graphql "^14.5.3"
 
-"@types/graphql@^14.5.0":
-  version "14.5.0"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.5.0.tgz#a545fb3bc8013a3547cf2f07f5e13a33642b75d6"
-  integrity sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==
-  dependencies:
-    graphql "*"
-
 "@types/http-assert@*":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.5.1.tgz#d775e93630c2469c2f980fc27e3143240335db3b"
@@ -2640,7 +2633,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1, commander@^2.18.0, commander@^2.20.3:
+commander@^2.12.1, commander@^2.18.0, commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3453,6 +3446,13 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+executioner@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/executioner/-/executioner-2.0.1.tgz#add328e03bc45dd598f358fbb529fc0be0ec6fcd"
+  integrity sha1-rdMo4DvEXdWY81j7tSn8C+Dsb80=
+  dependencies:
+    mixly "^1.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -3823,6 +3823,11 @@ fsevents@^2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+fulcon@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fulcon/-/fulcon-1.0.2.tgz#8a4dfda4c73fcd9cc62a79d5045c392b45547320"
+  integrity sha1-ik39pMc/zZzGKnnVBFw5K0VUcyA=
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -4122,12 +4127,7 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
-graphql@*:
-  version "15.3.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
-  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
-
-graphql@^14.5.3, graphql@^14.5.8:
+graphql@^14.5.3:
   version "14.7.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
   integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
@@ -4458,6 +4458,14 @@ inquirer@^7.3.3:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
+
+install-peers-cli@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/install-peers-cli/-/install-peers-cli-2.2.0.tgz#f76f1ec8ac9fa7f920c05743e011554edad85f8d"
+  integrity sha512-scSNvF49HDOLNm2xLFwST23g/OvfsceiA087bcGBgZP/ZNCrvpSaCn5IrWNZ2XYmFFykXF/6J1Zgm+D/JgRgtA==
+  dependencies:
+    commander "^2.20.0"
+    executioner "^2.0.1"
 
 interpret@^1.0.0:
   version "1.4.0"
@@ -5808,6 +5816,13 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mixly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mixly/-/mixly-1.0.0.tgz#9b5a2e1f63e6dfba0d30e6797ffae62ab1dc24ef"
+  integrity sha1-m1ouH2Pm37oNMOZ5f/rmKrHcJO8=
+  dependencies:
+    fulcon "^1.0.1"
 
 mkdirp@1.x:
   version "1.0.4"


### PR DESCRIPTION
This drops graphql as a dependency and replaces it with a peer-dependency. This means that you have
to install graphql versions 14 or 15 in your project when installing apollo-link-scalars

BREAKING CHANGE: graphql stops being a dependency and becomes a peer-dependency. It has to be added
directly to your project

fix #117
