### PR TITLE
feat: add nullable type transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # `apollo-link-scalars`
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 [![npm version](https://badge.fury.io/js/apollo-link-scalars.svg)](https://badge.fury.io/js/apollo-link-scalars)
@@ -91,6 +93,7 @@ We can pass extra options to `withScalars()` to modify the behaviour
 
 - **`removeTypenameFromInputs`** (`Boolean`, default `false`): when enabled, it will remove from the inputs the `__typename` if it is found. This could be useful if we are using data received from a query as an input on another query.
 - **`validateEnums`** (`Boolean`, default `false`): when enabled, it will validate the enums on parsing, throwing an error if it sees a value that is not one of the enum values.
+- **`nullFunction`** (`NullFunction`, default `null`): by passing a set of transforms on how to box and unbox null types, you can automatically construct e.g. Maybe monads from the null types. See below for an example.
 
 ```typescript
 withScalars({
@@ -178,6 +181,38 @@ const scalarsLink = withScalars({
   schema,
   typesMap: { … },
 });
+```
+
+#### Changing the behavior of nullable types
+
+By passing the `nullFunctions` parameter to `withScalar`, you can change the way that nullable types are handled. The default implementation will leave them exactly as is, i.e. `null` => `null` and `value` => `value`. If instead, you e.g. wish to transform nulls into a Maybe monad, you can supply functions corresponding to the following type. The examples below are based on the Maybe monad from [Seidr](https://github.com/hojberg/seidr) but any implementation will do.
+
+```typescript
+
+type NullFunctions = {
+  serialize(input: any): any | null;
+  parseValue(raw: any | null): any;
+};
+
+const nullFunctions: NullFunctions = {
+  parseValue(raw: any) {
+    if (isNone(raw)) {
+      return Nothing()
+    } else {
+      return Just(raw);
+    }
+  },
+  serialize(input: any) {
+    return input.caseOf({
+      Just(value) {
+        return value;
+      },
+      Nothing() {
+        return null;
+      }
+    })
+  },
+};
 ```
 
 ## Acknowledgements
@@ -295,6 +330,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/src/__tests__/nullable-functions.spec.ts
+++ b/src/__tests__/nullable-functions.spec.ts
@@ -1,0 +1,200 @@
+import { ApolloLink, DocumentNode, execute, gql, GraphQLRequest, Observable } from "@apollo/client/core";
+import { getOperationName } from "@apollo/client/utilities";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { withScalars } from "..";
+import { isNone } from "../lib/is-none";
+import { NullFunctions } from "../types/null-functions";
+
+const typeDefs = gql`
+  type Query {
+    exampleNullableArray: [String!]
+    exampleNullableNestedArray: [String]
+    nonNullObject: ExampleObject!
+    nullObject: ExampleObject
+  }
+
+  type ExampleObject {
+    nullField: String
+    nonNullField: String!
+  }
+
+  type MyInput {
+    nullField: String
+  }
+`;
+
+const schema = makeExecutableSchema({ typeDefs });
+
+const queryDocument: DocumentNode = gql`
+  query MyQuery($input: MyInput!) {
+    exampleNullableArray
+    exampleNullableNestedArray
+    nonNullObject {
+      nullField
+      nonNullField
+    }
+    nullObject {
+      nullField
+      nonNullField
+    }
+  }
+`;
+const queryOperationName = getOperationName(queryDocument);
+if (!queryOperationName) throw new Error("invalid query operation name");
+
+const responseWithNulls = {
+  data: {
+    exampleNullableArray: null,
+    exampleNullableNestedArray: [null],
+    nonNullObject: {
+      nullField: null,
+      nonNullField: "a",
+    },
+    nullObject: null,
+  },
+};
+
+const responseWithoutNulls = {
+  data: {
+    exampleNullableArray: ["a"],
+    exampleNullableNestedArray: [null, "b"],
+    nonNullObject: {
+      nullField: "c",
+      nonNullField: "d",
+    },
+    nullObject: {
+      nullField: "e",
+      nonNullField: "f",
+    },
+  },
+};
+
+describe("with default null functions", () => {
+  const request: GraphQLRequest = {
+    query: queryDocument,
+    variables: { input: { nullField: "a" } },
+    operationName: queryOperationName,
+  };
+  it("parses nulls correctly", (done) => {
+    const link = ApolloLink.from([
+      withScalars({ schema }),
+      new ApolloLink(() => {
+        return Observable.of(responseWithNulls);
+      }),
+    ]);
+
+    const observable = execute(link, request);
+    observable.subscribe((result) => {
+      expect(result).toEqual(responseWithNulls);
+      done();
+    });
+  });
+
+  it("parses non-nulls correctly", (done) => {
+    const link = ApolloLink.from([
+      withScalars({ schema }),
+      new ApolloLink(() => {
+        return Observable.of(responseWithoutNulls);
+      }),
+    ]);
+
+    const observable = execute(link, request);
+    observable.subscribe((result) => {
+      expect(result).toEqual(responseWithoutNulls);
+      done();
+    });
+  });
+});
+
+type Maybe<T> = {
+  typename: "just" | "nothing";
+  value?: T;
+};
+
+describe("with custom null functions", () => {
+  const request: GraphQLRequest = {
+    query: queryDocument,
+    variables: { input: { nullField: { typename: "just", value: "a" } } },
+    operationName: queryOperationName,
+  };
+
+  const nullFunctions: NullFunctions = {
+    parseValue(raw: any): Maybe<any> {
+      if (isNone(raw)) {
+        return {
+          typename: "nothing",
+        };
+      } else {
+        return {
+          typename: "just",
+          value: raw,
+        };
+      }
+    },
+    serialize(input: any) {
+      if (input.typename === "just") {
+        return input.value;
+      } else {
+        return null;
+      }
+    },
+  };
+  it("parses nulls correctly", (done) => {
+    const link = ApolloLink.from([
+      withScalars({ schema, nullFunctions }),
+      new ApolloLink(() => {
+        return Observable.of(responseWithNulls);
+      }),
+    ]);
+
+    const observable = execute(link, request);
+    observable.subscribe((result) => {
+      expect(result).toEqual({
+        data: {
+          exampleNullableArray: { typename: "nothing" },
+          exampleNullableNestedArray: { typename: "just", value: [{ typename: "nothing" }] },
+          nonNullObject: {
+            nullField: { typename: "nothing" },
+            nonNullField: "a",
+          },
+          nullObject: { typename: "nothing" },
+        },
+      });
+      done();
+    });
+  });
+
+  it("parses non-nulls correctly", (done) => {
+    const link = ApolloLink.from([
+      withScalars({ schema, nullFunctions }),
+      new ApolloLink(() => {
+        return Observable.of(responseWithoutNulls);
+      }),
+    ]);
+
+    const observable = execute(link, request);
+    observable.subscribe((result) => {
+      expect(result).toEqual({
+        data: {
+          exampleNullableArray: { typename: "just", value: ["a"] },
+          exampleNullableNestedArray: {
+            typename: "just",
+            value: [{ typename: "nothing" }, { typename: "just", value: "b" }],
+          },
+          nonNullObject: {
+            nullField: { typename: "just", value: "c" },
+            nonNullField: "d",
+          },
+          nullObject: {
+            typename: "just",
+            value: {
+              nullField: { typename: "just", value: "e" },
+              nonNullField: "f",
+            },
+          },
+        },
+      });
+      done();
+    });
+  });
+});

--- a/src/lib/__tests__/default-null-functions.spec.ts
+++ b/src/lib/__tests__/default-null-functions.spec.ts
@@ -1,0 +1,10 @@
+import defaultNullFunctions from "../default-null-functions";
+
+describe("default null functions", () => {
+  it("parses as identity", () => {
+    expect(defaultNullFunctions.parseValue("a")).toEqual("a");
+  });
+  it("serialies as identity", () => {
+    expect(defaultNullFunctions.serialize("a")).toEqual("a");
+  });
+});

--- a/src/lib/default-null-functions.ts
+++ b/src/lib/default-null-functions.ts
@@ -1,0 +1,16 @@
+import { NullFunctions } from "../types/null-functions";
+
+/**
+ * By default, make no transforms for null types. If you prefer, you could use these transforms to e.g.
+ * transform null into a Maybe monad.
+ */
+const defaultNullFunctions: NullFunctions = {
+  serialize(input: any) {
+    return input;
+  },
+  parseValue(raw: any) {
+    return raw;
+  },
+};
+
+export default defaultNullFunctions;

--- a/src/lib/link.ts
+++ b/src/lib/link.ts
@@ -3,6 +3,8 @@ import { GraphQLSchema, isInputType, isLeafType, NamedTypeNode, TypeNode } from 
 import pickBy from "lodash.pickby";
 import { ZenObservable } from "zen-observable-ts";
 import { FunctionsMap } from "..";
+import { NullFunctions } from "../types/null-functions";
+import defaultNullFunctions from "./default-null-functions";
 import { mapIfArray } from "./map-if-array";
 import { isListTypeNode, isNonNullTypeNode, isOperationDefinitionNode } from "./node-types";
 import { Serializer } from "./serializer";
@@ -13,6 +15,7 @@ type ScalarApolloLinkParams = {
   typesMap?: FunctionsMap;
   validateEnums?: boolean;
   removeTypenameFromInputs?: boolean;
+  nullFunctions?: NullFunctions;
 };
 
 export class ScalarApolloLink extends ApolloLink {
@@ -22,6 +25,7 @@ export class ScalarApolloLink extends ApolloLink {
   public readonly removeTypenameFromInputs: boolean;
   public readonly functionsMap: FunctionsMap;
   public readonly serializer: Serializer;
+  public readonly nullFunctions: NullFunctions;
 
   constructor(pars: ScalarApolloLinkParams) {
     super();
@@ -29,10 +33,11 @@ export class ScalarApolloLink extends ApolloLink {
     this.typesMap = pars.typesMap || {};
     this.validateEnums = pars.validateEnums || false;
     this.removeTypenameFromInputs = pars.removeTypenameFromInputs || false;
+    this.nullFunctions = pars.nullFunctions || defaultNullFunctions;
 
     const leafTypesMap = pickBy(this.schema.getTypeMap(), isLeafType);
     this.functionsMap = { ...leafTypesMap, ...this.typesMap };
-    this.serializer = new Serializer(this.schema, this.functionsMap, this.removeTypenameFromInputs);
+    this.serializer = new Serializer(this.schema, this.functionsMap, this.removeTypenameFromInputs, this.nullFunctions);
   }
 
   // ApolloLink code based on https://github.com/with-heart/apollo-link-response-resolver
@@ -72,6 +77,7 @@ export class ScalarApolloLink extends ApolloLink {
       functionsMap: this.functionsMap,
       schema: this.schema,
       validateEnums: this.validateEnums,
+      nullFunctions: this.nullFunctions,
     });
   }
 

--- a/src/lib/treat-result.ts
+++ b/src/lib/treat-result.ts
@@ -1,6 +1,7 @@
 import { FetchResult, Operation } from "@apollo/client/core";
 import { GraphQLObjectType, GraphQLSchema, OperationDefinitionNode } from "graphql";
 import { FunctionsMap } from "..";
+import { NullFunctions } from "../types/null-functions";
 import { fragmentReducer } from "./fragment-reducer";
 import { isFieldNode } from "./node-types";
 import { Parser } from "./parser";
@@ -30,6 +31,7 @@ type TreatResultParams = {
   operation: Operation;
   result: FetchResult;
   validateEnums: boolean;
+  nullFunctions: NullFunctions;
 };
 
 export function treatResult({
@@ -38,6 +40,7 @@ export function treatResult({
   operation,
   result,
   validateEnums,
+  nullFunctions,
 }: TreatResultParams): FetchResult {
   const data = result.data;
   if (!data) return result;
@@ -48,7 +51,7 @@ export function treatResult({
   const rootType = rootTypeFor(operationDefinitionNode, schema);
   if (!rootType) return result;
 
-  const parser = new Parser(schema, functionsMap, validateEnums);
+  const parser = new Parser(schema, functionsMap, validateEnums, nullFunctions);
   const rootSelections = operationDefinitionNode.selectionSet.selections.filter(isFieldNode);
   const newData = parser.parseObjectWithSelections(data, rootType, rootSelections);
   return { ...result, data: newData };

--- a/src/types/null-functions.ts
+++ b/src/types/null-functions.ts
@@ -1,0 +1,6 @@
+/* tslint:disable:interface-over-type-literal */
+
+export type NullFunctions = {
+  serialize(input: any): any | null;
+  parseValue(raw: any | null): any;
+};


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change implements nullable type transformations as in https://github.com/eturino/apollo-link-scalars/issues/235

* **What is the current behavior?** (You can also link to an open issue here)
There is no opportunity to transform nullable types. 

* **What is the new behavior (if this is a feature change)?**
You may supply a pair of transform functions to serialize and deserialize any nullable type. This allows for the creation of the Maybe monad from nullable types.

* **Other information**:

The core changes are (I hope!) fairly small - just a slightly different way of parsing the nullables and the option to pass the functions in.

I supplied a trivial implementation in the tests of what a different transform could look like without actually bringing our monad library in. I'm opening this now to give you a chance to look at it while we actually try to integrate this change into our main project - I'll let you know how we get on and if I think any changes are necessary.

Note that the transform itself is not well typed. I think this makes sense because, after all, all these transforms are being done in runtime anyway, but users should still be careful that their serialize and parse functions match appropriately. 

Let me know if there are any stylistic/design/other issues you wish addressed.

Cheers!
