### PR TITLE
fix: include src in npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src
 test
 tsconfig.json
 tsconfig.module.json


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Removes `src` from npmignore, thus including it with the package. That'll validate source maps as webpack can now link to the source files in development.

* **What is the current behavior?** (You can also link to an open issue here)

`src` is being ignored thus breaking source maps.

* **Other information**:

Create react app 5 (or Webpack 5) started throwing warnings about invalid source maps. After inspecting them I found that it's because src isn't being included with the npm package. Including it will stop the warnings and simplify debugging in development.