### PR TITLE
feat: reviveScalarsInCache — fix for issue #760 (persisted cache)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Parsing scalars at link level means that Apollo cache will receive them already 
 
 In the [original Apollo Client Github issue thread about scalar parsing](https://github.com/apollographql/apollo-client/issues/585), [this situation](https://github.com/apollographql/apollo-client/issues/585#issuecomment-400792837) [was discussed](https://github.com/apollographql/apollo-client/issues/585#issuecomment-400777797).
 
-At the time of this writing, Apollo Client still does not support this over 4 years after the original ticket was opened. A potential solution of parsing after the cache might have some other issues, like returning different instances for the cached data, which may not be ideal in some situations that rely on that (e.g. react re-render control). I think some users will benefit more from the automatic parsing and serializing than the cost of the potential cache interactions.
+Apollo Client still does not support this natively. The original 2016 ticket was closed in 2018 as a housekeeping redirect to [`apollographql/apollo-feature-requests#368`](https://github.com/apollographql/apollo-feature-requests/issues/368), which has been open ever since. A potential solution of parsing after the cache might have some other issues, like returning different instances for the cached data, which may not be ideal in some situations that rely on that (e.g. react re-render control). I think some users will benefit more from the automatic parsing and serializing than the cost of the potential cache interactions.
 
-**UPDATE**: [@woltob](https://github.com/woltob) has a proposal related to this: https://github.com/eturino/apollo-link-scalars/issues/760
+**UPDATE**: [@woltob](https://github.com/woltob) surfaced the JSON-backed persistence case in [issue #760](https://github.com/eturino/apollo-link-scalars/issues/760). The [`reviveScalarsInCache`](#rehydrating-a-persisted-cache-revivescalarsincache) helper documented below addresses it.
 
 ## Installation
 
@@ -236,6 +236,50 @@ if (isNone(value)) {
 const parsed = parseNonNullValue(value);
 return this.nullFunctions.parseValue(parsed);
 ```
+
+### Rehydrating a persisted cache (`reviveScalarsInCache`)
+
+`withScalars` runs inside the Apollo link chain, so it only parses operations flowing through the network. If you persist the Apollo cache with a JSON-backed store — [`apollo3-cache-persist`](https://github.com/apollographql/apollo-cache-persist), `AsyncStorage`, Redux-Persist, a custom adapter — the cache entries come back from storage as the shape JSON can hold: a custom `DateTime` becomes an ISO string, a custom `Money` becomes whatever `serialize` emitted, etc. The link never runs on rehydration, so the consumer never sees the parsed types. This is [issue #760](https://github.com/eturino/apollo-link-scalars/issues/760).
+
+`reviveScalarsInCache` is a pure, schema-driven helper that fixes this. Call it on the extracted cache snapshot to re-apply the custom `parseValue` functions to every scalar field declared in the schema, then hand the result back to `cache.restore`.
+
+```typescript
+import { reviveScalarsInCache, withScalars } from "apollo-link-scalars";
+import { LocalStorageWrapper, persistCache } from "apollo3-cache-persist";
+
+const cache = new InMemoryCache();
+
+await persistCache({ cache, storage: new LocalStorageWrapper(window.localStorage) });
+
+// `persistCache` has just repopulated the cache from storage. Revive the
+// snapshot so downstream cache reads see parsed scalars again.
+cache.restore(reviveScalarsInCache(cache.extract(), { schema, typesMap }));
+
+const client = new ApolloClient({
+  cache,
+  link: ApolloLink.from([withScalars({ schema, typesMap }), httpLink]),
+});
+```
+
+Works with any JSON-backed store, including ones that hand you the raw payload directly:
+
+```typescript
+const raw = JSON.parse(await AsyncStorage.getItem("apollo-cache"));
+cache.restore(reviveScalarsInCache(raw, { schema, typesMap }));
+```
+
+Options:
+
+- **`schema`** (required) — the same `GraphQLSchema` you pass to `withScalars`.
+- **`typesMap`** (required) — the same map you pass to `withScalars`. Entries here win over any `parseValue` defined on the schema scalar. Leaf types defined only on the schema are still applied (same merge behavior as `withScalars`).
+- **`nullFunctions`** (optional) — pass the same transform you pass to `withScalars` if you're boxing nullable values into a Maybe monad; nullable fields are wrapped through it on rehydration, matching what the link produces on the network path. Defaults to identity.
+
+Caveats:
+
+- Mutates the passed snapshot in place and returns the same reference. Pass a fresh object such as `cache.extract()` or a `JSON.parse(...)` result, not a live structure shared with the rest of the app.
+- Requires `__typename` on embedded non-normalized objects (Apollo's default — `new InMemoryCache()` adds it). Caches built with `addTypename: false` skip embedded object revival because there is no typename to look up in the schema. Top-level normalized entities still work because their `__typename` is part of the cache key Apollo writes regardless.
+- Interfaces, unions, and enum-scalar validation are out of scope in this first pass. Scalar fields nested under an interface- or union-typed field are not revived because the helper does not resolve the runtime `__typename` on the value itself the way the parser does.
+- Idempotence is caller-contingent. If you run the helper twice on the same snapshot, every scalar's `parseValue` runs twice. Safe only when `parseValue` detects its own output and short-circuits — e.g. `(v) => typeof v === "string" ? new Date(v) : v` leaves `Date` instances alone on a second pass. A naive `(v) => Number(v) * 100` will silently corrupt a second call (`150 -> 15000`).
 
 ## Acknowledgements
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { isNone } from "./lib/is-none";
 export { ScalarApolloLink, withScalars } from "./lib/link";
 export { mapIfArray } from "./lib/map-if-array";
-export { reviveScalarsInCache } from "./lib/revive-scalars-in-cache";
+export { reviveScalarsInCache, type ReviveScalarsInCacheOptions } from "./lib/revive-scalars-in-cache";
 export { FunctionsMap, ParsingFunctionsObject } from "./types/functions-map";
 export { NullFunctions } from "./types/null-functions";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { isNone } from "./lib/is-none";
 export { ScalarApolloLink, withScalars } from "./lib/link";
 export { mapIfArray } from "./lib/map-if-array";
+export { reviveScalarsInCache } from "./lib/revive-scalars-in-cache";
 export { FunctionsMap, ParsingFunctionsObject } from "./types/functions-map";
 export { NullFunctions } from "./types/null-functions";

--- a/src/lib/__tests__/revive-scalars-in-cache.spec.ts
+++ b/src/lib/__tests__/revive-scalars-in-cache.spec.ts
@@ -1,0 +1,192 @@
+import { buildSchema } from "graphql";
+import { reviveScalarsInCache } from "../revive-scalars-in-cache";
+
+// A schema covering the shapes we need to walk over the extracted cache:
+// - top-level scalars on entities (DateTime)
+// - scalar lists
+// - fields with arguments (ROOT_QUERY entries encode args into the cache
+//   key and we have to strip them to look up the schema field)
+// - embedded non-normalized objects with __typename
+const schema = buildSchema(`
+  scalar DateTime
+  scalar Money
+
+  type Author {
+    id: ID!
+    name: String!
+    joined: DateTime
+  }
+
+  type Post {
+    id: ID!
+    title: String!
+    createdAt: DateTime
+    tags: [String!]
+    prices: [Money!]
+    meta: Meta
+    author: Author
+  }
+
+  type Meta {
+    lastEditedAt: DateTime
+  }
+
+  type Query {
+    post(id: ID!): Post
+  }
+`);
+
+const typesMap = {
+  DateTime: {
+    serialize: (v: unknown) => (v instanceof Date ? v.toISOString() : v),
+    parseValue: (v: unknown) => (typeof v === "string" ? new Date(v) : v),
+  },
+  Money: {
+    serialize: (v: unknown) => String(v),
+    parseValue: (v: unknown) => (typeof v === "string" ? Number(v) * 100 : v),
+  },
+};
+
+describe("reviveScalarsInCache", () => {
+  it("parses a scalar field on a normalized entity", () => {
+    const extracted = {
+      "Post:1": {
+        __typename: "Post",
+        id: "1",
+        title: "hello",
+        createdAt: "2017-11-04T18:48:46.250Z",
+      },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    expect(out["Post:1"].createdAt).toBeInstanceOf(Date);
+    expect((out["Post:1"].createdAt as unknown as Date).toISOString()).toBe("2017-11-04T18:48:46.250Z");
+  });
+
+  it("leaves scalar fields absent from typesMap alone", () => {
+    const extracted = {
+      "Post:1": { __typename: "Post", id: "1", title: "hello" },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    expect(out["Post:1"].title).toBe("hello");
+  });
+
+  it("leaves null scalar values alone", () => {
+    const extracted = {
+      "Post:1": { __typename: "Post", id: "1", title: "hello", createdAt: null },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    expect(out["Post:1"].createdAt).toBeNull();
+  });
+
+  it("parses each element of a scalar list", () => {
+    const extracted = {
+      "Post:1": {
+        __typename: "Post",
+        id: "1",
+        title: "hello",
+        prices: ["1.50", "2.99"],
+      },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    expect(out["Post:1"].prices).toEqual([150, 299]);
+  });
+
+  it("does not touch scalar lists whose type is absent from typesMap", () => {
+    const extracted = {
+      "Post:1": { __typename: "Post", id: "1", title: "hello", tags: ["a", "b"] },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    expect(out["Post:1"].tags).toEqual(["a", "b"]);
+  });
+
+  it("strips arguments from cache field keys when looking up the schema", () => {
+    const extracted = {
+      ROOT_QUERY: {
+        __typename: "Query",
+        'post({"id":"1"})': { __ref: "Post:1" },
+      },
+      "Post:1": {
+        __typename: "Post",
+        id: "1",
+        title: "hello",
+        createdAt: "2017-11-04T18:48:46.250Z",
+      },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    expect(out["Post:1"].createdAt).toBeInstanceOf(Date);
+    expect(out.ROOT_QUERY['post({"id":"1"})']).toEqual({ __ref: "Post:1" });
+  });
+
+  it("recurses into embedded objects with __typename", () => {
+    const extracted = {
+      "Post:1": {
+        __typename: "Post",
+        id: "1",
+        title: "hello",
+        meta: { __typename: "Meta", lastEditedAt: "2020-01-02T00:00:00.000Z" },
+      },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    expect(out["Post:1"].meta).toBeDefined();
+    const meta = out["Post:1"].meta as unknown as { lastEditedAt: Date };
+    expect(meta.lastEditedAt).toBeInstanceOf(Date);
+  });
+
+  it("leaves __ref objects untouched", () => {
+    const extracted = {
+      "Post:1": {
+        __typename: "Post",
+        id: "1",
+        title: "hello",
+        author: { __ref: "Author:42" },
+      },
+      "Author:42": {
+        __typename: "Author",
+        id: "42",
+        name: "Ada",
+        joined: "1815-12-10T00:00:00.000Z",
+      },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    expect(out["Post:1"].author).toEqual({ __ref: "Author:42" });
+    // The referenced entity is walked at the top level, not via the __ref hop.
+    expect(out["Author:42"].joined).toBeInstanceOf(Date);
+  });
+
+  it("skips entries that are not entity objects", () => {
+    const extracted = {
+      "Post:1": { __typename: "Post", id: "1", title: "hello" },
+      stringEntry: "wat" as unknown,
+      nullEntry: null as unknown,
+    };
+    // Must not throw on non-object entries.
+    const out = reviveScalarsInCache(extracted as Record<string, unknown>, schema, typesMap);
+    expect(out.stringEntry).toBe("wat");
+    expect(out.nullEntry).toBeNull();
+  });
+
+  it("skips entities whose __typename is not in the schema", () => {
+    const extracted = {
+      "Ghost:1": { __typename: "Ghost", id: "1", createdAt: "2017-11-04T18:48:46.250Z" },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    // Unknown typename -> untouched, no crash.
+    expect(out["Ghost:1"].createdAt).toBe("2017-11-04T18:48:46.250Z");
+  });
+
+  it("is idempotent when parseValue returns the same shape", () => {
+    const extracted = {
+      "Post:1": {
+        __typename: "Post",
+        id: "1",
+        title: "hello",
+        createdAt: "2017-11-04T18:48:46.250Z",
+      },
+    };
+    const once = reviveScalarsInCache(extracted, schema, typesMap);
+    // Second pass should be a no-op (parseValue keeps Date instances as-is).
+    const twice = reviveScalarsInCache(once, schema, typesMap);
+    expect(twice["Post:1"].createdAt).toBeInstanceOf(Date);
+    expect((twice["Post:1"].createdAt as unknown as Date).toISOString()).toBe("2017-11-04T18:48:46.250Z");
+  });
+});

--- a/src/lib/__tests__/revive-scalars-in-cache.spec.ts
+++ b/src/lib/__tests__/revive-scalars-in-cache.spec.ts
@@ -23,6 +23,7 @@ const schema = buildSchema(`
     createdAt: DateTime
     tags: [String!]
     prices: [Money!]
+    requiredPrices: [Money!]!
     meta: Meta
     author: Author
   }
@@ -33,6 +34,7 @@ const schema = buildSchema(`
 
   type Query {
     post(id: ID!): Post
+    now(scale: String): DateTime
   }
 `);
 
@@ -172,6 +174,32 @@ describe("reviveScalarsInCache", () => {
     const out = reviveScalarsInCache(extracted, schema, typesMap);
     // Unknown typename -> untouched, no crash.
     expect(out["Ghost:1"].createdAt).toBe("2017-11-04T18:48:46.250Z");
+  });
+
+  it("parses every element of a non-null list of non-null scalars", () => {
+    const extracted = {
+      "Post:1": {
+        __typename: "Post",
+        id: "1",
+        title: "hello",
+        requiredPrices: ["1.50", "2.99", "10.00"],
+      },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    expect(out["Post:1"].requiredPrices).toEqual([150, 299, 1000]);
+  });
+
+  it("parses a scalar field with arguments stored under ROOT_QUERY", () => {
+    const extracted = {
+      ROOT_QUERY: {
+        __typename: "Query",
+        'now({"scale":"utc"})': "2021-06-15T12:00:00.000Z",
+      },
+    };
+    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const value = out.ROOT_QUERY['now({"scale":"utc"})'];
+    expect(value).toBeInstanceOf(Date);
+    expect((value as unknown as Date).toISOString()).toBe("2021-06-15T12:00:00.000Z");
   });
 
   it("is idempotent when parseValue returns the same shape", () => {

--- a/src/lib/__tests__/revive-scalars-in-cache.spec.ts
+++ b/src/lib/__tests__/revive-scalars-in-cache.spec.ts
@@ -59,7 +59,7 @@ describe("reviveScalarsInCache", () => {
         createdAt: "2017-11-04T18:48:46.250Z",
       },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     expect(out["Post:1"].createdAt).toBeInstanceOf(Date);
     expect((out["Post:1"].createdAt as unknown as Date).toISOString()).toBe("2017-11-04T18:48:46.250Z");
   });
@@ -68,7 +68,7 @@ describe("reviveScalarsInCache", () => {
     const extracted = {
       "Post:1": { __typename: "Post", id: "1", title: "hello" },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     expect(out["Post:1"].title).toBe("hello");
   });
 
@@ -76,7 +76,7 @@ describe("reviveScalarsInCache", () => {
     const extracted = {
       "Post:1": { __typename: "Post", id: "1", title: "hello", createdAt: null },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     expect(out["Post:1"].createdAt).toBeNull();
   });
 
@@ -89,7 +89,7 @@ describe("reviveScalarsInCache", () => {
         prices: ["1.50", "2.99"],
       },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     expect(out["Post:1"].prices).toEqual([150, 299]);
   });
 
@@ -97,7 +97,7 @@ describe("reviveScalarsInCache", () => {
     const extracted = {
       "Post:1": { __typename: "Post", id: "1", title: "hello", tags: ["a", "b"] },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     expect(out["Post:1"].tags).toEqual(["a", "b"]);
   });
 
@@ -114,7 +114,7 @@ describe("reviveScalarsInCache", () => {
         createdAt: "2017-11-04T18:48:46.250Z",
       },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     expect(out["Post:1"].createdAt).toBeInstanceOf(Date);
     expect(out.ROOT_QUERY['post({"id":"1"})']).toEqual({ __ref: "Post:1" });
   });
@@ -128,7 +128,7 @@ describe("reviveScalarsInCache", () => {
         meta: { __typename: "Meta", lastEditedAt: "2020-01-02T00:00:00.000Z" },
       },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     expect(out["Post:1"].meta).toBeDefined();
     const meta = out["Post:1"].meta as unknown as { lastEditedAt: Date };
     expect(meta.lastEditedAt).toBeInstanceOf(Date);
@@ -149,7 +149,7 @@ describe("reviveScalarsInCache", () => {
         joined: "1815-12-10T00:00:00.000Z",
       },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     expect(out["Post:1"].author).toEqual({ __ref: "Author:42" });
     // The referenced entity is walked at the top level, not via the __ref hop.
     expect(out["Author:42"].joined).toBeInstanceOf(Date);
@@ -162,7 +162,7 @@ describe("reviveScalarsInCache", () => {
       nullEntry: null as unknown,
     };
     // Must not throw on non-object entries.
-    const out = reviveScalarsInCache(extracted as Record<string, unknown>, schema, typesMap);
+    const out = reviveScalarsInCache(extracted as Record<string, unknown>, { schema, typesMap });
     expect(out.stringEntry).toBe("wat");
     expect(out.nullEntry).toBeNull();
   });
@@ -171,7 +171,7 @@ describe("reviveScalarsInCache", () => {
     const extracted = {
       "Ghost:1": { __typename: "Ghost", id: "1", createdAt: "2017-11-04T18:48:46.250Z" },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     // Unknown typename -> untouched, no crash.
     expect(out["Ghost:1"].createdAt).toBe("2017-11-04T18:48:46.250Z");
   });
@@ -185,7 +185,7 @@ describe("reviveScalarsInCache", () => {
         requiredPrices: ["1.50", "2.99", "10.00"],
       },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     expect(out["Post:1"].requiredPrices).toEqual([150, 299, 1000]);
   });
 
@@ -196,7 +196,7 @@ describe("reviveScalarsInCache", () => {
         'now({"scale":"utc"})': "2021-06-15T12:00:00.000Z",
       },
     };
-    const out = reviveScalarsInCache(extracted, schema, typesMap);
+    const out = reviveScalarsInCache(extracted, { schema, typesMap });
     const value = out.ROOT_QUERY['now({"scale":"utc"})'];
     expect(value).toBeInstanceOf(Date);
     expect((value as unknown as Date).toISOString()).toBe("2021-06-15T12:00:00.000Z");
@@ -217,7 +217,7 @@ describe("reviveScalarsInCache", () => {
     const extracted = {
       "Event:1": { __typename: "Event", id: "1", when: "2022-08-01T00:00:00.000Z" },
     };
-    const out = reviveScalarsInCache(extracted, localSchema, {});
+    const out = reviveScalarsInCache(extracted, { schema: localSchema, typesMap: {} });
     expect(out["Event:1"].when).toBeInstanceOf(Date);
   });
 
@@ -233,10 +233,61 @@ describe("reviveScalarsInCache", () => {
     const extracted = {
       "Event:1": { __typename: "Event", id: "1", when: "2022-08-01T00:00:00.000Z" },
     };
-    const out = reviveScalarsInCache(extracted, localSchema, {
-      Timestamp: { serialize: (v) => v, parseValue: () => "from-typesMap" },
+    const out = reviveScalarsInCache(extracted, {
+      schema: localSchema,
+      typesMap: { Timestamp: { serialize: (v) => v, parseValue: () => "from-typesMap" } },
     });
     expect(out["Event:1"].when).toBe("from-typesMap");
+  });
+
+  it("wraps nullable field values through nullFunctions.parseValue but leaves non-null alone", () => {
+    // Mirrors `parser.ts` behavior: `nullFunctions.parseValue` only runs on
+    // nullable fields (see `parser.ts:77-80`). A caller using a Maybe monad
+    // on the network path via `withScalars` can repeat the same
+    // `nullFunctions` here and get the same shape after rehydration.
+    const localSchema = buildSchema(`
+      scalar DateTime
+      type Post { id: ID! nullableWhen: DateTime requiredWhen: DateTime! }
+      type Query { post(id: ID!): Post }
+    `);
+    const tsMap = {
+      DateTime: {
+        serialize: (v: unknown) => (v instanceof Date ? v.toISOString() : v),
+        parseValue: (v: unknown) => (typeof v === "string" ? new Date(v) : v),
+      },
+    };
+    const nullFunctions = {
+      serialize: (v: unknown) => v,
+      parseValue: (raw: unknown) =>
+        raw === null || raw === undefined ? { kind: "None" as const } : { kind: "Some" as const, value: raw },
+    };
+
+    const extracted = {
+      "Post:1": {
+        __typename: "Post",
+        id: "1",
+        nullableWhen: "2021-01-01T00:00:00.000Z",
+        requiredWhen: "2022-01-01T00:00:00.000Z",
+      },
+      "Post:2": {
+        __typename: "Post",
+        id: "2",
+        nullableWhen: null,
+        requiredWhen: "2022-01-01T00:00:00.000Z",
+      },
+    };
+
+    const out = reviveScalarsInCache(extracted, { schema: localSchema, typesMap: tsMap, nullFunctions });
+
+    // Nullable field with a value: scalar parsed first, then wrapped.
+    expect(out["Post:1"].nullableWhen).toEqual({
+      kind: "Some",
+      value: expect.any(Date),
+    });
+    // Non-null field: no wrap.
+    expect(out["Post:1"].requiredWhen).toBeInstanceOf(Date);
+    // Nullable field with null: scalar skipped, null wrapped.
+    expect(out["Post:2"].nullableWhen).toEqual({ kind: "None" });
   });
 
   it("is idempotent when parseValue returns the same shape", () => {
@@ -248,9 +299,9 @@ describe("reviveScalarsInCache", () => {
         createdAt: "2017-11-04T18:48:46.250Z",
       },
     };
-    const once = reviveScalarsInCache(extracted, schema, typesMap);
+    const once = reviveScalarsInCache(extracted, { schema, typesMap });
     // Second pass should be a no-op (parseValue keeps Date instances as-is).
-    const twice = reviveScalarsInCache(once, schema, typesMap);
+    const twice = reviveScalarsInCache(once, { schema, typesMap });
     expect(twice["Post:1"].createdAt).toBeInstanceOf(Date);
     expect((twice["Post:1"].createdAt as unknown as Date).toISOString()).toBe("2017-11-04T18:48:46.250Z");
   });

--- a/src/lib/__tests__/revive-scalars-in-cache.spec.ts
+++ b/src/lib/__tests__/revive-scalars-in-cache.spec.ts
@@ -1,4 +1,4 @@
-import { buildSchema } from "graphql";
+import { buildSchema, type GraphQLScalarType } from "graphql";
 import { reviveScalarsInCache } from "../revive-scalars-in-cache";
 
 // A schema covering the shapes we need to walk over the extracted cache:
@@ -200,6 +200,43 @@ describe("reviveScalarsInCache", () => {
     const value = out.ROOT_QUERY['now({"scale":"utc"})'];
     expect(value).toBeInstanceOf(Date);
     expect((value as unknown as Date).toISOString()).toBe("2021-06-15T12:00:00.000Z");
+  });
+
+  it("uses the schema scalar's parseValue when typesMap has no entry", () => {
+    // Same shape `ScalarApolloLink` applies on the network path: scalar
+    // types carrying a programmatic `parseValue` are honored even when
+    // the caller's `typesMap` omits them.
+    const localSchema = buildSchema(`
+      scalar Timestamp
+      type Event { id: ID! when: Timestamp }
+      type Query { event(id: ID!): Event }
+    `);
+    const timestamp = localSchema.getType("Timestamp") as GraphQLScalarType;
+    timestamp.parseValue = (value: unknown) => (typeof value === "string" ? new Date(value) : value);
+
+    const extracted = {
+      "Event:1": { __typename: "Event", id: "1", when: "2022-08-01T00:00:00.000Z" },
+    };
+    const out = reviveScalarsInCache(extracted, localSchema, {});
+    expect(out["Event:1"].when).toBeInstanceOf(Date);
+  });
+
+  it("lets typesMap override the schema scalar's parseValue", () => {
+    const localSchema = buildSchema(`
+      scalar Timestamp
+      type Event { id: ID! when: Timestamp }
+      type Query { event(id: ID!): Event }
+    `);
+    const timestamp = localSchema.getType("Timestamp") as GraphQLScalarType;
+    timestamp.parseValue = () => "from-schema";
+
+    const extracted = {
+      "Event:1": { __typename: "Event", id: "1", when: "2022-08-01T00:00:00.000Z" },
+    };
+    const out = reviveScalarsInCache(extracted, localSchema, {
+      Timestamp: { serialize: (v) => v, parseValue: () => "from-typesMap" },
+    });
+    expect(out["Event:1"].when).toBe("from-typesMap");
   });
 
   it("is idempotent when parseValue returns the same shape", () => {

--- a/src/lib/revive-scalars-in-cache.ts
+++ b/src/lib/revive-scalars-in-cache.ts
@@ -31,6 +31,18 @@ import { isNone } from "./is-none";
  * @example
  * await persistCache({ cache, storage });
  * cache.restore(reviveScalarsInCache(cache.extract(), schema, typesMap));
+ *
+ * @remarks
+ * Idempotence is caller-contingent. `reviveScalarsInCache` calls
+ * `parseValue` once per field per pass, so invoking it twice on the
+ * same snapshot parses every scalar twice. Safe only when the
+ * supplied `parseValue` is itself idempotent — e.g. a `DateTime`
+ * parser that guards with `typeof v === "string"` before constructing
+ * a `Date` will leave `Date` instances alone on the second pass. A
+ * naive `Money` parser like `(v) => Number(v) * 100` is NOT
+ * idempotent: first pass turns `"1.50"` into `150`, second pass turns
+ * `150` into `15000` — silent corruption. When in doubt, make
+ * `parseValue` detect its own output and short-circuit.
  */
 export function reviveScalarsInCache<T extends Record<string, unknown>>(
   extracted: T,

--- a/src/lib/revive-scalars-in-cache.ts
+++ b/src/lib/revive-scalars-in-cache.ts
@@ -57,6 +57,21 @@ export interface ReviveScalarsInCacheOptions {
  * null-monad transform passed to `withScalars` can be repeated here
  * to keep both paths producing the same shape.
  *
+ * Requires `__typename` on embedded non-normalized objects, which is
+ * Apollo's default behavior. A cache built with
+ * `new InMemoryCache({ addTypename: false })` stores embedded objects
+ * without a `__typename` key, so `reviveScalarsInCache` cannot look
+ * them up in the schema and will leave their scalars unparsed.
+ * Top-level normalized entities still work because their cache key
+ * (`Foo:1`) and their `__typename` field are written by Apollo
+ * independent of the `addTypename` setting.
+ *
+ * Interfaces, unions, and enum-scalar validation are out of scope in
+ * this first pass. Scalar fields nested under an interface- or
+ * union-typed field are not revived because the helper does not
+ * resolve the runtime `__typename` on the value itself the way the
+ * network parser does.
+ *
  * Idempotence is caller-contingent. `reviveScalarsInCache` calls
  * `parseValue` once per field per pass, so invoking it twice on the
  * same snapshot parses every scalar twice. Safe only when the

--- a/src/lib/revive-scalars-in-cache.ts
+++ b/src/lib/revive-scalars-in-cache.ts
@@ -1,0 +1,108 @@
+import {
+  type GraphQLOutputType,
+  type GraphQLSchema,
+  isListType,
+  isNonNullType,
+  isObjectType,
+  isScalarType,
+} from "graphql";
+import type { FunctionsMap } from "../types/functions-map";
+import { isNone } from "./is-none";
+
+/**
+ * Re-applies the custom scalar `parseValue` functions to a cache snapshot that
+ * has been round-tripped through JSON (localStorage / AsyncStorage / any store
+ * that uses `apollo3-cache-persist` or equivalent).
+ *
+ * Fix for https://github.com/eturino/apollo-link-scalars/issues/760 — the
+ * scalar link only sees operations flowing through `ApolloLink`, so values
+ * restored via `cache.restore()` come back as the JSON shape they had in
+ * storage (`Date` -> ISO string, custom `Money` -> the serialized form, etc.)
+ * and the consumer never gets the parsed types.
+ *
+ * Pure and schema-driven: no dependency on `ApolloCache`. Call it on the
+ * payload *before* `cache.restore(...)` or after you read it from the
+ * persisted store yourself.
+ *
+ * @example
+ * const raw = JSON.parse(await AsyncStorage.getItem("apollo-cache"));
+ * cache.restore(reviveScalarsInCache(raw, schema, typesMap));
+ *
+ * @example
+ * await persistCache({ cache, storage });
+ * cache.restore(reviveScalarsInCache(cache.extract(), schema, typesMap));
+ */
+export function reviveScalarsInCache<T extends Record<string, unknown>>(
+  extracted: T,
+  schema: GraphQLSchema,
+  typesMap: FunctionsMap
+): T {
+  for (const value of Object.values(extracted)) {
+    if (isEntityObject(value)) {
+      reviveEntity(value, schema, typesMap);
+    }
+  }
+  return extracted;
+}
+
+interface EntityObject {
+  __typename?: string;
+  [key: string]: unknown;
+}
+
+function isEntityObject(value: unknown): value is EntityObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRef(value: unknown): value is { __ref: string } {
+  return isEntityObject(value) && typeof (value as { __ref?: unknown }).__ref === "string";
+}
+
+// Cache field keys may encode call arguments as `fieldName({"id":"1"})` or with
+// keyArgs as `fieldName:{"id":"1"}`. Strip anything from the first `(` or `:`
+// onwards so we can look up the field on the schema type.
+function extractFieldName(cacheKey: string): string {
+  const parenIdx = cacheKey.indexOf("(");
+  const colonIdx = cacheKey.indexOf(":");
+  const boundaries = [parenIdx, colonIdx].filter((i) => i >= 0);
+  return boundaries.length === 0 ? cacheKey : cacheKey.slice(0, Math.min(...boundaries));
+}
+
+function reviveEntity(entity: EntityObject, schema: GraphQLSchema, typesMap: FunctionsMap): void {
+  const typename = entity.__typename;
+  if (!typename) return;
+  const type = schema.getType(typename);
+  if (!isObjectType(type)) return;
+  const fields = type.getFields();
+
+  for (const cacheKey of Object.keys(entity)) {
+    if (cacheKey === "__typename") continue;
+    const field = fields[extractFieldName(cacheKey)];
+    if (!field) continue;
+    entity[cacheKey] = reviveValue(entity[cacheKey], field.type, schema, typesMap);
+  }
+}
+
+function reviveValue(value: unknown, type: GraphQLOutputType, schema: GraphQLSchema, typesMap: FunctionsMap): unknown {
+  if (isNone(value)) return value;
+  const nullable = isNonNullType(type) ? type.ofType : type;
+
+  if (isListType(nullable)) {
+    if (!Array.isArray(value)) return value;
+    return value.map((element) => reviveValue(element, nullable.ofType, schema, typesMap));
+  }
+
+  if (isScalarType(nullable)) {
+    const funcs = typesMap[nullable.name];
+    return funcs ? funcs.parseValue(value) : value;
+  }
+
+  // Embedded non-normalized object (has __typename inline) — recurse.
+  // Normalized references (__ref) are walked via the top-level loop instead.
+  if (isObjectType(nullable) && isEntityObject(value) && !isRef(value)) {
+    reviveEntity(value, schema, typesMap);
+  }
+
+  // Interfaces, unions, enums, ref objects fall through unchanged.
+  return value;
+}

--- a/src/lib/revive-scalars-in-cache.ts
+++ b/src/lib/revive-scalars-in-cache.ts
@@ -1,6 +1,8 @@
 import {
+  type GraphQLLeafType,
   type GraphQLOutputType,
   type GraphQLSchema,
+  isLeafType,
   isListType,
   isNonNullType,
   isObjectType,
@@ -33,6 +35,18 @@ import { isNone } from "./is-none";
  * cache.restore(reviveScalarsInCache(cache.extract(), schema, typesMap));
  *
  * @remarks
+ * Mutates `extracted` in place and returns the same reference. The
+ * generic signature is there for type flow, not copy semantics. Pass
+ * a fresh snapshot such as `cache.extract()` (already a clone of the
+ * live cache) or a `JSON.parse(...)` result; don't pass a live
+ * in-memory structure shared with the rest of the app.
+ *
+ * Merges `typesMap` with the schema's own leaf types the same way
+ * `withScalars` does (see `src/lib/link.ts`). A scalar defined
+ * programmatically via `new GraphQLScalarType({ parseValue })` will
+ * therefore be applied on rehydration even when the caller's
+ * `typesMap` omits it, matching the network-path behavior.
+ *
  * Idempotence is caller-contingent. `reviveScalarsInCache` calls
  * `parseValue` once per field per pass, so invoking it twice on the
  * same snapshot parses every scalar twice. Safe only when the
@@ -49,12 +63,25 @@ export function reviveScalarsInCache<T extends Record<string, unknown>>(
   schema: GraphQLSchema,
   typesMap: FunctionsMap
 ): T {
+  const functionsMap = buildFunctionsMap(schema, typesMap);
   for (const value of Object.values(extracted)) {
     if (isEntityObject(value)) {
-      reviveEntity(value, schema, typesMap);
+      reviveEntity(value, schema, functionsMap);
     }
   }
   return extracted;
+}
+
+// Mirror of `ScalarApolloLink`'s constructor logic (`src/lib/link.ts`):
+// take every leaf type off the schema and let the caller's `typesMap`
+// override it. Keeps the revive path and the network path in lockstep
+// on which scalars get `parseValue`'d.
+function buildFunctionsMap(schema: GraphQLSchema, typesMap: FunctionsMap): FunctionsMap {
+  const leafTypesMap: Record<string, GraphQLLeafType> = {};
+  for (const [key, value] of Object.entries(schema.getTypeMap())) {
+    if (isLeafType(value)) leafTypesMap[key] = value;
+  }
+  return { ...leafTypesMap, ...typesMap };
 }
 
 interface EntityObject {
@@ -80,7 +107,7 @@ function extractFieldName(cacheKey: string): string {
   return boundaries.length === 0 ? cacheKey : cacheKey.slice(0, Math.min(...boundaries));
 }
 
-function reviveEntity(entity: EntityObject, schema: GraphQLSchema, typesMap: FunctionsMap): void {
+function reviveEntity(entity: EntityObject, schema: GraphQLSchema, functionsMap: FunctionsMap): void {
   const typename = entity.__typename;
   if (!typename) return;
   const type = schema.getType(typename);
@@ -91,28 +118,33 @@ function reviveEntity(entity: EntityObject, schema: GraphQLSchema, typesMap: Fun
     if (cacheKey === "__typename") continue;
     const field = fields[extractFieldName(cacheKey)];
     if (!field) continue;
-    entity[cacheKey] = reviveValue(entity[cacheKey], field.type, schema, typesMap);
+    entity[cacheKey] = reviveValue(entity[cacheKey], field.type, schema, functionsMap);
   }
 }
 
-function reviveValue(value: unknown, type: GraphQLOutputType, schema: GraphQLSchema, typesMap: FunctionsMap): unknown {
+function reviveValue(
+  value: unknown,
+  type: GraphQLOutputType,
+  schema: GraphQLSchema,
+  functionsMap: FunctionsMap
+): unknown {
   if (isNone(value)) return value;
   const nullable = isNonNullType(type) ? type.ofType : type;
 
   if (isListType(nullable)) {
     if (!Array.isArray(value)) return value;
-    return value.map((element) => reviveValue(element, nullable.ofType, schema, typesMap));
+    return value.map((element) => reviveValue(element, nullable.ofType, schema, functionsMap));
   }
 
   if (isScalarType(nullable)) {
-    const funcs = typesMap[nullable.name];
-    return funcs ? funcs.parseValue(value) : value;
+    const funcs = functionsMap[nullable.name] ?? nullable;
+    return funcs.parseValue(value);
   }
 
   // Embedded non-normalized object (has __typename inline) — recurse.
   // Normalized references (__ref) are walked via the top-level loop instead.
   if (isObjectType(nullable) && isEntityObject(value) && !isRef(value)) {
-    reviveEntity(value, schema, typesMap);
+    reviveEntity(value, schema, functionsMap);
   }
 
   // Interfaces, unions, enums, ref objects fall through unchanged.

--- a/src/lib/revive-scalars-in-cache.ts
+++ b/src/lib/revive-scalars-in-cache.ts
@@ -9,7 +9,15 @@ import {
   isScalarType,
 } from "graphql";
 import type { FunctionsMap } from "../types/functions-map";
+import type { NullFunctions } from "../types/null-functions";
+import defaultNullFunctions from "./default-null-functions";
 import { isNone } from "./is-none";
+
+export interface ReviveScalarsInCacheOptions {
+  schema: GraphQLSchema;
+  typesMap: FunctionsMap;
+  nullFunctions?: NullFunctions;
+}
 
 /**
  * Re-applies the custom scalar `parseValue` functions to a cache snapshot that
@@ -28,11 +36,11 @@ import { isNone } from "./is-none";
  *
  * @example
  * const raw = JSON.parse(await AsyncStorage.getItem("apollo-cache"));
- * cache.restore(reviveScalarsInCache(raw, schema, typesMap));
+ * cache.restore(reviveScalarsInCache(raw, { schema, typesMap }));
  *
  * @example
  * await persistCache({ cache, storage });
- * cache.restore(reviveScalarsInCache(cache.extract(), schema, typesMap));
+ * cache.restore(reviveScalarsInCache(cache.extract(), { schema, typesMap }));
  *
  * @remarks
  * Mutates `extracted` in place and returns the same reference. The
@@ -41,11 +49,13 @@ import { isNone } from "./is-none";
  * live cache) or a `JSON.parse(...)` result; don't pass a live
  * in-memory structure shared with the rest of the app.
  *
- * Merges `typesMap` with the schema's own leaf types the same way
- * `withScalars` does (see `src/lib/link.ts`). A scalar defined
- * programmatically via `new GraphQLScalarType({ parseValue })` will
- * therefore be applied on rehydration even when the caller's
- * `typesMap` omits it, matching the network-path behavior.
+ * Merges `typesMap` with the schema's own leaf types and honors
+ * `nullFunctions` the same way `withScalars` does (see
+ * `src/lib/link.ts`). A scalar defined programmatically via
+ * `new GraphQLScalarType({ parseValue })` is therefore applied on
+ * rehydration even when the caller's `typesMap` omits it, and any
+ * null-monad transform passed to `withScalars` can be repeated here
+ * to keep both paths producing the same shape.
  *
  * Idempotence is caller-contingent. `reviveScalarsInCache` calls
  * `parseValue` once per field per pass, so invoking it twice on the
@@ -60,16 +70,25 @@ import { isNone } from "./is-none";
  */
 export function reviveScalarsInCache<T extends Record<string, unknown>>(
   extracted: T,
-  schema: GraphQLSchema,
-  typesMap: FunctionsMap
+  options: ReviveScalarsInCacheOptions
 ): T {
-  const functionsMap = buildFunctionsMap(schema, typesMap);
+  const ctx: RevivalContext = {
+    schema: options.schema,
+    functionsMap: buildFunctionsMap(options.schema, options.typesMap),
+    nullFunctions: options.nullFunctions ?? defaultNullFunctions,
+  };
   for (const value of Object.values(extracted)) {
     if (isEntityObject(value)) {
-      reviveEntity(value, schema, functionsMap);
+      reviveEntity(value, ctx);
     }
   }
   return extracted;
+}
+
+interface RevivalContext {
+  schema: GraphQLSchema;
+  functionsMap: FunctionsMap;
+  nullFunctions: NullFunctions;
 }
 
 // Mirror of `ScalarApolloLink`'s constructor logic (`src/lib/link.ts`):
@@ -107,10 +126,10 @@ function extractFieldName(cacheKey: string): string {
   return boundaries.length === 0 ? cacheKey : cacheKey.slice(0, Math.min(...boundaries));
 }
 
-function reviveEntity(entity: EntityObject, schema: GraphQLSchema, functionsMap: FunctionsMap): void {
+function reviveEntity(entity: EntityObject, ctx: RevivalContext): void {
   const typename = entity.__typename;
   if (!typename) return;
-  const type = schema.getType(typename);
+  const type = ctx.schema.getType(typename);
   if (!isObjectType(type)) return;
   const fields = type.getFields();
 
@@ -118,33 +137,39 @@ function reviveEntity(entity: EntityObject, schema: GraphQLSchema, functionsMap:
     if (cacheKey === "__typename") continue;
     const field = fields[extractFieldName(cacheKey)];
     if (!field) continue;
-    entity[cacheKey] = reviveValue(entity[cacheKey], field.type, schema, functionsMap);
+    entity[cacheKey] = reviveValue(entity[cacheKey], field.type, ctx);
   }
 }
 
-function reviveValue(
-  value: unknown,
-  type: GraphQLOutputType,
-  schema: GraphQLSchema,
-  functionsMap: FunctionsMap
-): unknown {
-  if (isNone(value)) return value;
+// Matches `parser.ts`'s `treatValue` / `treatValueNullable` split: only
+// nullable fields get wrapped through `nullFunctions.parseValue`, and the
+// wrap happens AFTER the inner scalar / list / object revival.
+function reviveValue(value: unknown, type: GraphQLOutputType, ctx: RevivalContext): unknown {
+  if (isNonNullType(type)) {
+    return reviveValueInternal(value, type, ctx);
+  }
+  const wrapped = reviveValueInternal(value, type, ctx);
+  return ctx.nullFunctions.parseValue(wrapped);
+}
+
+function reviveValueInternal(value: unknown, type: GraphQLOutputType, ctx: RevivalContext): unknown {
   const nullable = isNonNullType(type) ? type.ofType : type;
+  if (isNone(value)) return value;
 
   if (isListType(nullable)) {
     if (!Array.isArray(value)) return value;
-    return value.map((element) => reviveValue(element, nullable.ofType, schema, functionsMap));
+    return value.map((element) => reviveValue(element, nullable.ofType, ctx));
   }
 
   if (isScalarType(nullable)) {
-    const funcs = functionsMap[nullable.name] ?? nullable;
+    const funcs = ctx.functionsMap[nullable.name] ?? nullable;
     return funcs.parseValue(value);
   }
 
   // Embedded non-normalized object (has __typename inline) — recurse.
   // Normalized references (__ref) are walked via the top-level loop instead.
   if (isObjectType(nullable) && isEntityObject(value) && !isRef(value)) {
-    reviveEntity(value, schema, functionsMap);
+    reviveEntity(value, ctx);
   }
 
   // Interfaces, unions, enums, ref objects fall through unchanged.

--- a/test-apps/apollo-v4-persisted-cache/e2e/persistence-fix.spec.ts
+++ b/test-apps/apollo-v4-persisted-cache/e2e/persistence-fix.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Fix path for issue #760: `reviveScalarsInCache(cache.extract(), schema,
+ * typesMap)` re-applies `parseValue` to the cache snapshot after
+ * `apollo3-cache-persist` rehydrates it from localStorage. The consumer
+ * sees real Date instances again — both when reading synchronously on
+ * mount and when Apollo serves the query from cache on a later call.
+ */
+test("reviveScalarsInCache restores Date scalars after rehydration (v4)", async ({ page }) => {
+  const browserMessages: string[] = [];
+  page.on("console", (msg) => {
+    const type = msg.type();
+    if (type === "error" || type === "warning") {
+      browserMessages.push(`[${type}] ${msg.text()}`);
+    }
+  });
+  page.on("pageerror", (err) => browserMessages.push(`[pageerror] ${err.message}`));
+
+  // Phase 1: seed the cache via a live network fetch without the fix toggle.
+  // This writes the scalar link's parsed payload into memory and localStorage.
+  await page.goto("/");
+  await page.evaluate(() => {
+    window.localStorage.clear();
+  });
+  await page.reload();
+
+  await page.getByTestId("button-fetch").click();
+  await expect(page.getByTestId("last-source")).toHaveText("network");
+  await expect(page.getByTestId("rendered-is-date")).toHaveText("true");
+
+  await page.waitForFunction(
+    () => window.localStorage.getItem("apollo-cache-persist") !== null,
+  );
+
+  // Phase 2: reload with the fix toggle. reviveScalarsInCache runs right
+  // after persistCache's restore, so the cache entry holds Date instances
+  // when the page reads it on mount.
+  await page.goto("/?fix=1");
+
+  await expect(page.getByTestId("fix-flag")).toHaveText("on");
+  await expect(page.getByTestId("cached-type")).toHaveText("object");
+  await expect(page.getByTestId("cached-is-date")).toHaveText("true");
+  await expect(page.getByTestId("cached-iso")).toHaveText(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+  );
+
+  // Phase 3: cache-first query pulls from memory (0 network hits). The
+  // scalar link still never runs on this path, but the revive step means
+  // the consumer receives a Date instance anyway.
+  await page.getByTestId("button-fetch").click();
+  await expect(page.getByTestId("last-source")).toHaveText("cache");
+  await expect(page.getByTestId("rendered-type")).toHaveText("object");
+  await expect(page.getByTestId("rendered-is-date")).toHaveText("true");
+  await expect(page.getByTestId("network-count")).toHaveText("0");
+
+  expect(
+    browserMessages,
+    `browser logged errors/warnings:\n${browserMessages.join("\n")}`,
+  ).toHaveLength(0);
+});

--- a/test-apps/apollo-v4-persisted-cache/src/App.tsx
+++ b/test-apps/apollo-v4-persisted-cache/src/App.tsx
@@ -25,7 +25,7 @@ function describe(value: unknown): {
   };
 }
 
-export function App() {
+export function App({ applyFix }: { applyFix: boolean }) {
   const client = useApolloClient();
   const [lastSource, setLastSource] = useState<"never" | "network" | "cache">("never");
   const [renderedChar, setRenderedChar] = useState<Character | null>(null);
@@ -64,6 +64,10 @@ export function App() {
         Reproduces <a href="https://github.com/eturino/apollo-link-scalars/issues/760">issue #760</a>:
         custom scalars parsed by the link are re-hydrated from localStorage as plain JSON values,
         bypassing the scalar map.
+      </p>
+      <p>
+        Fix path: <span data-testid="fix-flag">{applyFix ? "on" : "off"}</span> — toggle by
+        navigating to <code>?fix=1</code>.
       </p>
 
       <section>

--- a/test-apps/apollo-v4-persisted-cache/src/apollo.ts
+++ b/test-apps/apollo-v4-persisted-cache/src/apollo.ts
@@ -63,7 +63,7 @@ export async function bootstrap({ applyFix = false }: { applyFix?: boolean } = {
   // on the snapshot, and restore it back so downstream cache reads see
   // properly typed scalars again.
   if (applyFix) {
-    cache.restore(reviveScalarsInCache(cache.extract(), schema, typesMap));
+    cache.restore(reviveScalarsInCache(cache.extract(), { schema, typesMap }));
   }
 
   return new ApolloClient({

--- a/test-apps/apollo-v4-persisted-cache/src/apollo.ts
+++ b/test-apps/apollo-v4-persisted-cache/src/apollo.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, ApolloLink, HttpLink, InMemoryCache, gql } from "@apollo/client";
 import { makeExecutableSchema } from "@graphql-tools/schema";
-import { withScalars } from "apollo-link-scalars";
+import { reviveScalarsInCache, withScalars } from "apollo-link-scalars";
 import { LocalStorageWrapper, persistCache } from "apollo3-cache-persist";
 
 const typeDefs = gql`
@@ -47,7 +47,7 @@ const trackingLink = new ApolloLink((operation, forward) => {
 
 const httpLink = new HttpLink({ uri: "https://rickandmortyapi.com/graphql" });
 
-export async function bootstrap(): Promise<ApolloClient> {
+export async function bootstrap({ applyFix = false }: { applyFix?: boolean } = {}): Promise<ApolloClient> {
   const cache = new InMemoryCache();
   await persistCache({
     cache,
@@ -56,6 +56,16 @@ export async function bootstrap(): Promise<ApolloClient> {
     // Playwright doesn't have to wait out the library's default debounce.
     debounce: 0,
   });
+
+  // persistCache has just repopulated InMemoryCache from localStorage. The
+  // restored entries have JSON-shaped scalars (Date -> ISO string etc.). When
+  // `applyFix` is on, snapshot the current state, run `reviveScalarsInCache`
+  // on the snapshot, and restore it back so downstream cache reads see
+  // properly typed scalars again.
+  if (applyFix) {
+    cache.restore(reviveScalarsInCache(cache.extract(), schema, typesMap));
+  }
+
   return new ApolloClient({
     cache,
     link: ApolloLink.from([withScalars({ schema, typesMap }), trackingLink, httpLink]),

--- a/test-apps/apollo-v4-persisted-cache/src/main.tsx
+++ b/test-apps/apollo-v4-persisted-cache/src/main.tsx
@@ -4,12 +4,16 @@ import ReactDOM from "react-dom/client";
 import { App } from "./App";
 import { bootstrap } from "./apollo";
 
-const client = await bootstrap();
+// URL flag picks between the issue #760 reproduction and the
+// reviveScalarsInCache fix path. Playwright toggles it via `?fix=1`.
+const applyFix = new URLSearchParams(window.location.search).get("fix") === "1";
+
+const client = await bootstrap({ applyFix });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ApolloProvider client={client}>
-      <App />
+      <App applyFix={applyFix} />
     </ApolloProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

Closes the structural gap [issue #760](https://github.com/eturino/apollo-link-scalars/issues/760) identified: `apollo-link-scalars` only parses scalars on operations flowing through `ApolloLink`, so values restored from JSON-backed cache storage (`apollo3-cache-persist`, `AsyncStorage`, Redux-Persist, custom adapters) come back as the plain JSON shape they had in storage — `DateTime` becomes an ISO string, a custom `Money` becomes whatever `serialize` emitted, etc.

New exported helper walks an extracted cache snapshot and re-applies `parseValue` to every scalar field, matching what `withScalars` does on the network path:

```ts
import { reviveScalarsInCache, withScalars } from "apollo-link-scalars";

await persistCache({ cache, storage });
cache.restore(reviveScalarsInCache(cache.extract(), { schema, typesMap }));
```

Pure, schema-driven, no `ApolloCache` dependency. Works with any JSON-backed store that hands you the raw shape.

## What's in the helper

- `src/lib/revive-scalars-in-cache.ts` — walks `extracted` entries, looks each entity's `__typename` up in the schema, strips call-args from cache field keys (`field({"id":"1"})` → `field`, `field:{"a":1}` → `field`), and applies `parseValue` to scalar fields; recurses into embedded non-normalized objects with `__typename`; leaves `__ref` objects alone (their targets are walked at the top level).
- `src/index.ts` — exports `reviveScalarsInCache` and the `ReviveScalarsInCacheOptions` type.
- `src/lib/__tests__/revive-scalars-in-cache.spec.ts` — 16 unit tests.
- `test-apps/apollo-v4-persisted-cache` — wires the fix into the existing #760 test-app behind a `?fix=1` URL toggle. `persistence-fix.spec.ts` asserts the fix path; `persistence.spec.ts` still asserts the broken baseline at the default URL so a regression in the link pipeline would surface.
- `README.md` — new "Rehydrating a persisted cache" section in Usage, plus a refreshed disclaimer paragraph that points at the helper.

## Network-path parity

The helper is wired to mirror `ScalarApolloLink` / `parser.ts` behavior so the two paths produce the same shape:

| concern | `withScalars` (network) | `reviveScalarsInCache` (rehydration) |
|---|---|---|
| scalar fallback to schema's `parseValue` | yes, merge of `leafTypesMap` + `typesMap` in `link.ts:54-60` | yes, same merge inside the helper |
| `nullFunctions.parseValue` wrap on nullable values | yes (`parser.ts:77-80`) | yes, via optional `nullFunctions` option (defaults to identity) |
| non-null unwrap + list recursion | yes | yes |
| `null` / `undefined` passthrough | yes | yes |
| interfaces, unions, enum-scalar validation | yes | out of scope in v1 |

## Signature

Positional args age badly once `nullFunctions` joins the party (and interfaces/unions will want their own knobs later), so the helper takes an options bag:

```ts
reviveScalarsInCache(
  extracted: T,
  options: {
    schema: GraphQLSchema;
    typesMap: FunctionsMap;
    nullFunctions?: NullFunctions; // defaults to identity
  }
): T
```

Mutates `extracted` in place and returns the same reference — pass a fresh object like `cache.extract()` or a `JSON.parse(...)` result.

## Coverage (v1)

| case | behavior |
|---|---|
| top-level scalar on normalized entity | parsed |
| scalar in typesMap, `null` value | null wrapped through `nullFunctions` if set, passthrough otherwise |
| field absent from typesMap | schema scalar's own `parseValue` applied (matches `withScalars`) |
| scalar list (`[T]` / `[T!]` / `[T!]!`) | each element parsed |
| list of type not in typesMap | elements get schema scalar's `parseValue` (identity for SDL-only scalars) |
| cache key with args (`field({...})`, `field:{...}`) | field name extracted, parsed |
| scalar field on `ROOT_QUERY` with args (`now({"scale":"utc"})`) | parsed |
| embedded non-normalized object with `__typename` | recursed |
| `__ref` object | left alone (target walked at top level) |
| unknown `__typename` | skipped, no throw |
| non-object entry (string/null) | skipped, no throw |
| `nullFunctions` on nullable vs non-null fields | wrap applied on nullable only, matching `parser.ts:77-80` |
| second pass on same data | idempotent when caller's `parseValue` is idempotent (documented) |

Out of scope for v1: interface/union field types (need runtime `__typename` resolution on the value), enum-scalar validation (needs a policy parallel to `validateEnums`), embedded objects on caches built with `addTypename: false` (no typename to dispatch on).

## Stacked on

Base: `chore/migrate-to-vitest` (#1555)

Full stack:
- chore/dev-deps-upgrade → test/react-apps (#1553) → test/persisted-cache-issue-760 (#1554) → chore/migrate-to-vitest (#1555) → **this**.

## Test plan

- [x] `pnpm test` — 16 new unit tests green, all existing 69 still pass, lint/prettier/knip/dpdm/type-check all clean, all three test-apps build
- [x] `pnpm e2e:run` — persistence.spec (broken baseline) + persistence-fix.spec (fix path) + v3/v4 react specs all green
- [ ] CI: watch test + matrix jobs